### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
-- PUPPET_VERSION=3.3.1
+- PUPPET_VERSION=2.7.23
+- PUPPET_VERSION=3.3.2
 notifications:
 email: false
 rvm:
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,13 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-   Dir['manifests/**/*.pp'].each do |path|
-     sh "puppet parser validate --noop #{path}"
-   end
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 describe 'localization' do
 
+  it { should compile.with_all_deps }
+
   context 'with default options' do
-    it {
-      should include_class('localization')
-    }
+    it { should contain_class('localization') }
   end
 
   context 'with languages specified as a hash' do
@@ -48,7 +48,7 @@ describe 'localization' do
 
     it do
       expect {
-        should include_class('localization')
+        should contain_class('localization')
       }.to raise_error(Puppet::Error)
     end
   end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
